### PR TITLE
Update weather api host URL

### DIFF
--- a/src/main/resources/api.properties
+++ b/src/main/resources/api.properties
@@ -4,7 +4,7 @@ api.timeout = 3000
 # Weather API
 weather.api.name = forecast.io API
 weather.api.key = YOUR_KEY_HERE
-weather.api.host = api.forecast.io
+weather.api.host = api.darksky.net
 
 # Weather Icons
 clear-day = wi-day-sunny


### PR DESCRIPTION
Weather api host is not working anymore. 
Updated with correct one, `api.darksky.net`